### PR TITLE
EXE: Replace AddVectoredExceptionHandler with ...

### DIFF
--- a/src/exe/crashdump.h
+++ b/src/exe/crashdump.h
@@ -1,7 +1,7 @@
 #pragma once
 
 void CrashDumpInitialize();
-LONG CALLBACK CrashDumpVectorHandler(EXCEPTION_POINTERS* ExceptionInfo);
-void InvalidParameterHandler(const wchar_t* Expression, const wchar_t* Function, const wchar_t* File, unsigned int Line, uintptr_t Reserved);
+LONG CALLBACK CrashDumpExceptionHandler(EXCEPTION_POINTERS *ExceptionInfo);
+void InvalidParameterHandler(const wchar_t *Expression, const wchar_t *Function, const wchar_t *File, unsigned int Line, uintptr_t Reserved);
 void TerminateHandler();
 void AbortHandler(int Signal);


### PR DESCRIPTION
SetUnhandledExceptionFilter.

This fixes an issue (or a C++ exception being thrown rather) and caught by the the handler instead of the runtime dll, where application that runs in a 64-bit version of Windows are ignored (per Microsoft: https://support.microsoft.com/en-gb/kb/976038).